### PR TITLE
fix(release): :bug: skip husky pre-push hook in CI so semantic-releas…

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,8 @@
+# This is a LOCAL developer gate only. Never run it in CI — semantic-release
+# does its own `git push`, which would otherwise re-trigger this hook and
+# re-run the whole suite inside the release job. GitHub Actions sets CI=true.
+[ -n "$CI" ] && exit 0
+
 # Mirror the CI gate locally so failures surface BEFORE they hit GitHub.
 # Matches the fast jobs in .github/workflows/ci.yml. Bypass with `--no-verify`
 # only when you know what you're doing.


### PR DESCRIPTION
This pull request adds a local developer safeguard to the `.husky/pre-push` git hook to prevent it from running in Continuous Integration (CI) environments. This ensures that the pre-push checks are only run during local development and not during automated CI processes.

Development workflow improvement:

* Updated `.husky/pre-push` to exit early if the `CI` environment variable is set, preventing the hook from running in CI environments and avoiding redundant test executions during automated releases.…e can push