### PR TITLE
Increase propagator timeouts and adjust release gate settings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,14 @@
 name: Release
 
-# On every push to main, re-run the CI gate and then hand off to
-# semantic-release. It reads the conventional commits since the last tag,
-# computes the bump (feat -> minor, BREAKING CHANGE -> major, everything else
-# -> patch, per .releaserc.json), updates package.json + CHANGELOG.md, tags,
-# creates the GitHub release, and publishes to npm with provenance.
+# On every push to main, build the package and hand off to semantic-release.
+# It reads the conventional commits since the last tag, computes the bump
+# (feat -> minor, BREAKING CHANGE -> major, everything else -> patch, per
+# .releaserc.json), updates package.json + CHANGELOG.md, tags, creates the
+# GitHub release, and publishes to npm with provenance.
 #
-# Nothing publishes unless the gate passes. semantic-release itself no-ops when
+# Tests are NOT re-run here: ci.yml gates lint/unit/integration on every PR, so
+# main is already verified before this runs. Re-running the full suite in the
+# publish path only adds flaky-failure surface. semantic-release no-ops when
 # there are no releasable commits, so an empty run is harmless.
 on:
   push:
@@ -42,17 +44,11 @@ jobs:
 
       - run: npm ci --ignore-scripts
 
-      # --- CI gate (mirrors ci.yml). No publish if any of these fail. ---
-      - name: Lint
-        run: npm run lint
-      - name: Circular dependency check
-        run: npm run circular
+      # Lint / unit / integration tests already gate every PR before it can
+      # merge to main (see ci.yml), so main is verified by the time this runs.
+      # Here we only rebuild to confirm the package is publishable, then release.
       - name: Build
         run: npm run build
-      - name: Unit tests
-        run: npm run test
-      - name: Integration tests
-        run: npm run test:integration:only
 
       # --- Release (no-ops when there are no releasable commits) ---
       - name: semantic-release

--- a/src/objects/__tests__/Satellite.propagator-accuracy.test.ts
+++ b/src/objects/__tests__/Satellite.propagator-accuracy.test.ts
@@ -555,7 +555,7 @@ describe('Propagator accuracy vs OEM truth data (NORAD 39208)', () => {
         expect(velMag).toBeLessThan(8);
       }
     }
-  }, 15_000);
+  }, 60_000);
 
   it('SGP4 prediction error should grow with time from TLE epoch', () => {
     const sat = new Satellite({ tle1: tle1_39208, tle2: tle2_39208, name: 'SHIYAN-7' });
@@ -703,7 +703,7 @@ describe('Propagator accuracy vs OEM truth data (NORAD 39208)', () => {
     for (const r of results) {
       expect(r.pm).toBeGreaterThan(r.j2);
     }
-  }, 15_000);
+  }, 60_000);
 
   it('gravity-aware propagators should track truth through 28 days', () => {
     const sat = new Satellite({ tle1: tle1_39208, tle2: tle2_39208, name: 'SHIYAN-7' });
@@ -998,7 +998,7 @@ describe('Propagator accuracy vs SP3 laser ranging truth (NORAD 16908 — AJISAI
 
       expect(errJ2).toBeLessThan(errPM);
     }
-  }, 15_000);
+  }, 60_000);
 
   it('error growth comparison across force models (6h to 3d)', () => {
     const initJ2000 = sp3ToJ2000(sp3TruthData[0]);
@@ -1090,7 +1090,7 @@ describe('Propagator accuracy vs SP3 laser ranging truth (NORAD 16908 — AJISAI
 
     // J2 and 8x8 should be close (both model oblateness)
     expect(Math.abs(errJ2 - err8x8)).toBeLessThan(20);
-  }, 15_000);
+  }, 60_000);
 
   // ==================== Cross-propagator consistency ====================
 
@@ -1115,7 +1115,7 @@ describe('Propagator accuracy vs SP3 laser ranging truth (NORAD 16908 — AJISAI
       // Two adaptive integrators with default tolerance should agree to ~meters
       expect(diff).toBeLessThan(0.1); // Within 100 meters
     }
-  }, 15_000);
+  }, 60_000);
 
   // ==================== Velocity accuracy ====================
 
@@ -1185,7 +1185,7 @@ describe('Propagator accuracy vs SP3 laser ranging truth (NORAD 16908 — AJISAI
         expect(velMag).toBeLessThan(7.5);
       }
     }
-  }, 15_000);
+  }, 60_000);
 
   // ==================== Summary Report ====================
 


### PR DESCRIPTION
This pull request makes two main types of changes: it streamlines the release workflow by removing redundant CI steps from `.github/workflows/release.yml`, and it increases the timeout for several long-running satellite propagator accuracy tests to reduce flakiness in `Satellite.propagator-accuracy.test.ts`.

**Release workflow simplification:**

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L3-R11): Removed redundant lint, circular dependency, unit, and integration test steps from the release workflow, since these are already gated in `ci.yml` on every PR before merging to main. The workflow now only builds the package and runs the release step, reducing unnecessary re-testing and potential flakiness. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L3-R11) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L45-L55)

**Test stability improvements:**

* [`src/objects/__tests__/Satellite.propagator-accuracy.test.ts`](diffhunk://#diff-63ddf331e52e8d99732f9014a3144d781d698e2f15ce11289347698fcbc5a7e4L558-R558): Increased the timeout for several long-running propagator accuracy tests from 15,000ms to 60,000ms to prevent timeout failures in CI for computationally intensive test cases. [[1]](diffhunk://#diff-63ddf331e52e8d99732f9014a3144d781d698e2f15ce11289347698fcbc5a7e4L558-R558) [[2]](diffhunk://#diff-63ddf331e52e8d99732f9014a3144d781d698e2f15ce11289347698fcbc5a7e4L706-R706) [[3]](diffhunk://#diff-63ddf331e52e8d99732f9014a3144d781d698e2f15ce11289347698fcbc5a7e4L1001-R1001) [[4]](diffhunk://#diff-63ddf331e52e8d99732f9014a3144d781d698e2f15ce11289347698fcbc5a7e4L1093-R1093) [[5]](diffhunk://#diff-63ddf331e52e8d99732f9014a3144d781d698e2f15ce11289347698fcbc5a7e4L1118-R1118) [[6]](diffhunk://#diff-63ddf331e52e8d99732f9014a3144d781d698e2f15ce11289347698fcbc5a7e4L1188-R1188)