### PR TITLE
Fix GitHub Pages deployment and custom domain serving

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,12 @@ jobs:
           cache: 'npm'
 
       - name: Configure Pages
+        # enablement: turn Pages on (build type = GitHub Actions) via the API if
+        # it isn't already, so the deploy step doesn't fail with
+        # "Deployment failed, try again later".
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       # --ignore-scripts skips husky install; no hooks needed to build docs.
       - run: npm ci --ignore-scripts

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -3,7 +3,10 @@ import { defineConfig } from 'vitepress';
 export default defineConfig({
   title: 'ootk',
   description: 'Orbital Object Toolkit - satellite propagation, orbit determination, sensors, and maneuver planning in TypeScript',
-  base: '/ootk/',
+  // Served at the root of the custom domain (ootk.kruczeklabs.com), so base is
+  // '/'. If you ever drop the custom domain and serve at thkruz.github.io/ootk/,
+  // change this back to '/ootk/'.
+  base: '/',
   // README.md stays for GitHub folder browsing; index.md is the site home
   srcExclude: ['README.md'],
   themeConfig: {

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+ootk.kruczeklabs.com


### PR DESCRIPTION
This pull request updates the documentation deployment process and configuration to support serving the site at a custom domain (`ootk.kruczeklabs.com`). The changes ensure that GitHub Pages is properly enabled, the site is served from the correct base path, and the custom domain is set.

Deployment and configuration updates:

* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR47-R52): Configures the GitHub Actions workflow to explicitly enable GitHub Pages via the API before deployment, preventing possible deployment failures if Pages is not already enabled.
* [`docs/.vitepress/config.mts`](diffhunk://#diff-e3dd2227e911b905c0de197c1154f07c408373635ac0434607068133835e88deL6-R9): Updates the VitePress config to set the `base` path to `'/'`, reflecting that the site is served from the root of the custom domain instead of a subdirectory.
* [`docs/public/CNAME`](diffhunk://#diff-ffa0036a42cb9c4fdd60012c278a58cfb0040d63aebbed326d831e45d9cf74abR1): Adds a `CNAME` file specifying `ootk.kruczeklabs.com` as the custom domain for GitHub Pages.